### PR TITLE
Chore: Ensure Python 3.9 Compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3,9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ lightning_logs/
 test.txt
 derivatives_seg
 robert_test.py
+poetry.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,11 @@ torchmetrics = "^1.1.2"
 tqdm = "^4.66.1"
 einops= "^0.6.1"
 nnunetv2 = "2.4.2"
-#TPTBox = "^0.2.1"
+TPTBox = "^0.2.1"
 antspyx = "0.4.2"
 rich = "^13.6.0"
 monai="^1.3.0"
-TypeSaveArgParse="1.0.0"
+TypeSaveArgParse="^1.0.1"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ spineps = 'spineps.entrypoint:entry_point'
 spineps_ = 'spineps.entrypoint:entrypoint_no_checks'
 
 [tool.poetry.dependencies]
-python = "^3.10 || ^3.11"
+python = "^3.9 || ^3.10 || ^3.11"
 connected-components-3d = "^3.12.3"
 fill-voids = "^2.0.5"
 nibabel = "^5.1.0"
@@ -31,11 +31,11 @@ torchmetrics = "^1.1.2"
 tqdm = "^4.66.1"
 einops= "^0.6.1"
 nnunetv2 = "2.4.2"
-TPTBox = "^0.2.1"
+#TPTBox = "^0.2.1"
 antspyx = "0.4.2"
 rich = "^13.6.0"
 monai="^1.3.0"
-TypeSaveArgParse="^1.0.1"
+#TypeSaveArgParse="1.0.0"
 
 
 [tool.poetry.dev-dependencies]
@@ -47,7 +47,7 @@ pandas = "^2.1.0"
 joblib = "^1.3.2"
 future = "^0.18.3"
 flake8 = ">=4.0.1"
-auxiliary = ">=0.1.0"
+#auxiliary = ">=0.1.0"
 tqdm = ">=4.62.3"
 
 
@@ -162,6 +162,8 @@ ignore = [
     "SIM118", # dictionay keys
     "N802", # function name lowercase
     "PLR2044", # empty comment symbol
+    "B905", # strict= in zip()
+    "UP007", # Union instead of | in python 3.9
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ nnunetv2 = "2.4.2"
 antspyx = "0.4.2"
 rich = "^13.6.0"
 monai="^1.3.0"
-#TypeSaveArgParse="1.0.0"
+TypeSaveArgParse="1.0.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/spineps/architectures/pl_densenet.py
+++ b/spineps/architectures/pl_densenet.py
@@ -9,10 +9,11 @@ import pytorch_lightning as pl
 import torch
 from monai.networks.nets import DenseNet169
 from torch import nn
+from TypeSaveArgParse import Class_to_ArgParse
 
 
 @dataclass
-class ARGS_MODEL:
+class ARGS_MODEL(Class_to_ArgParse):
     classification_conv: bool = False
     classification_linear: bool = True
     #

--- a/spineps/architectures/pl_densenet.py
+++ b/spineps/architectures/pl_densenet.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from dataclasses import dataclass
@@ -7,11 +9,10 @@ import pytorch_lightning as pl
 import torch
 from monai.networks.nets import DenseNet169
 from torch import nn
-from TypeSaveArgParse import Class_to_ArgParse
 
 
 @dataclass
-class ARGS_MODEL(Class_to_ArgParse):
+class ARGS_MODEL:
     classification_conv: bool = False
     classification_linear: bool = True
     #

--- a/spineps/architectures/pl_unet.py
+++ b/spineps/architectures/pl_unet.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 import pytorch_lightning as pl

--- a/spineps/architectures/read_labels.py
+++ b/spineps/architectures/read_labels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from enum import Enum
 

--- a/spineps/architectures/unet3D.py
+++ b/spineps/architectures/unet3D.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import partial
 
 import torch
@@ -31,7 +33,7 @@ class Unet3D(nn.Module):
         self.init_conv = nn.Conv3d((channels + conditional_dimensions), init_dim, 7, padding=3)
 
         dims = [init_dim, *(int(dim * m) for m in dim_mults)]
-        in_out = list(zip(dims[:-1], dims[1:], strict=True))  # noqa: RUF007
+        in_out = list(zip(dims[:-1], dims[1:]))  # noqa: RUF007
 
         block_klass = partial(ResnetBlock3D, groups=resnet_block_groups)
         time_dim = None

--- a/spineps/entrypoint.py
+++ b/spineps/entrypoint.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import cProfile
 import os

--- a/spineps/example/get_gpu.py
+++ b/spineps/example/get_gpu.py
@@ -1,4 +1,6 @@
-import time  # noqa: INP001
+from __future__ import annotations
+
+import time # noqa: INP001
 
 import GPUtil
 from TPTBox import Log_Type, No_Logger

--- a/spineps/example/helper_parallel.py
+++ b/spineps/example/helper_parallel.py
@@ -1,4 +1,6 @@
-import sys  # noqa: INP001
+from __future__ import annotations
+
+import sys # noqa: INP001
 from pathlib import Path
 
 file = Path(__file__).resolve()

--- a/spineps/example/template_roll_out.py
+++ b/spineps/example/template_roll_out.py
@@ -1,4 +1,6 @@
-import sys  # noqa: INP001
+from __future__ import annotations
+
+import sys # noqa: INP001
 from pathlib import Path
 
 file = Path(__file__).resolve()

--- a/spineps/example/template_roll_out.py
+++ b/spineps/example/template_roll_out.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import sys # noqa: INP001
+import sys
 from pathlib import Path
 
 file = Path(__file__).resolve()

--- a/spineps/get_models.py
+++ b/spineps/get_models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/spineps/lab_model.py
+++ b/spineps/lab_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/spineps/phase_instance.py
+++ b/spineps/phase_instance.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # from utils.predictor import nnUNetPredictor
 import numpy as np
 from TPTBox import NII, Location, Log_Type

--- a/spineps/phase_labeling.py
+++ b/spineps/phase_labeling.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from enum import Enum
 from pathlib import Path

--- a/spineps/phase_post.py
+++ b/spineps/phase_post.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # from utils.predictor import nnUNetPredictor
 import heapq
 
@@ -363,7 +365,7 @@ def label_instance_top_to_bottom(vert_nii: NII, labeling_offset: int = 0):
     vert_nii.reorient_()
     vert_arr = vert_nii.get_seg_array()
     com_i = np_center_of_mass(vert_arr)
-    comb_l = list(zip(com_i.keys(), com_i.values(), strict=True))
+    comb_l = list(zip(com_i.keys(), com_i.values()))
     comb_l.sort(key=lambda a: a[1][1])  # PIR
     com_map = {comb_l[idx][0]: idx + 1 + labeling_offset for idx in range(len(comb_l))}
 

--- a/spineps/phase_post.py
+++ b/spineps/phase_post.py
@@ -21,6 +21,7 @@ from TPTBox.core.np_utils import (
 
 from spineps.phase_labeling import VertLabelingClassifier, perform_labeling_step
 from spineps.seg_pipeline import logger, vertebra_subreg_labels
+from spineps.utils.compat import zip_strict
 from spineps.utils.proc_functions import fix_wrong_posterior_instance_label
 
 
@@ -365,7 +366,7 @@ def label_instance_top_to_bottom(vert_nii: NII, labeling_offset: int = 0):
     vert_nii.reorient_()
     vert_arr = vert_nii.get_seg_array()
     com_i = np_center_of_mass(vert_arr)
-    comb_l = list(zip(com_i.keys(), com_i.values()))
+    comb_l = list(zip_strict(com_i.keys(), com_i.values()))
     comb_l.sort(key=lambda a: a[1][1])  # PIR
     com_map = {comb_l[idx][0]: idx + 1 + labeling_offset for idx in range(len(comb_l))}
 

--- a/spineps/phase_pre.py
+++ b/spineps/phase_pre.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # from utils.predictor import nnUNetPredictor
 from time import perf_counter
 

--- a/spineps/phase_semantic.py
+++ b/spineps/phase_semantic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # from utils.predictor import nnUNetPredictor
 from time import perf_counter
 

--- a/spineps/seg_enums.py
+++ b/spineps/seg_enums.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum, EnumMeta, auto
 
 from typing_extensions import Self

--- a/spineps/seg_model.py
+++ b/spineps/seg_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path

--- a/spineps/seg_pipeline.py
+++ b/spineps/seg_pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # from utils.predictor import nnUNetPredictor
 import subprocess
 from typing import Any

--- a/spineps/seg_run.py
+++ b/spineps/seg_run.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 from collections.abc import Callable

--- a/spineps/seg_utils.py
+++ b/spineps/seg_utils.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 # from utils.predictor import nnUNetPredictor
+from typing import Union
+
 import nibabel as nib
 from TPTBox import BIDS_FILE, NII, ZOOMS, Log_Type
 
@@ -6,7 +10,7 @@ from spineps.seg_enums import Acquisition, Modality
 from spineps.seg_model import Segmentation_Model
 from spineps.seg_pipeline import logger
 
-Modality_Pair = tuple[list[Modality] | Modality, Acquisition]
+Modality_Pair = tuple[Union[list[Modality], Modality], Acquisition]
 
 
 def find_best_matching_model(

--- a/spineps/utils/auto_download.py
+++ b/spineps/utils/auto_download.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shutil
 import urllib.request
 import zipfile

--- a/spineps/utils/citation_reminder.py
+++ b/spineps/utils/citation_reminder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import atexit
 import os
 

--- a/spineps/utils/compat.py
+++ b/spineps/utils/compat.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+
+def zip_strict(*iterables):
+    """
+    A strict version of zip that raises a ValueError if the input iterables have different lengths.
+
+    Converts each iterable to a list to check lengths. This assumes all iterables are finite.
+
+    Args:
+        *iterables: Finite iterables to be zipped together.
+
+    Returns:
+        An iterator of tuples, where the i-th tuple contains the i-th element from each iterable.
+
+    Raises:
+        ValueError: If the input iterables have different lengths.
+    """
+    lists = [list(it) for it in iterables]
+    lengths = [len(lst) for lst in lists]
+    if len(set(lengths)) != 1:
+        raise ValueError(f"Length mismatch: {lengths}")
+    return zip(*lists)

--- a/spineps/utils/data_iterators.py
+++ b/spineps/utils/data_iterators.py
@@ -1,6 +1,7 @@
 # Adapted from https://github.com/MIC-DKFZ/nnUNet
 # Isensee, F., Jaeger, P. F., Kohl, S. A., Petersen, J., & Maier-Hein, K. H. (2021). nnU-Net: a self-configuring
 # method for deep learning-based biomedical image segmentation. Nature methods, 18(2), 203-211.
+from __future__ import annotations
 
 from typing import Union, List
 

--- a/spineps/utils/default_preprocessor.py
+++ b/spineps/utils/default_preprocessor.py
@@ -7,7 +7,7 @@ import numpy as np
 
 # from acvl_utils.miscellaneous.ptqdm import ptqdm
 from batchgenerators.utilities.file_and_folder_operations import *
-from acvl_utils.cropping_and_padding.bounding_boxes import get_bbox_from_mask, crop_to_bbox, bounding_box_to_slice
+from acvl_utils.cropping_and_padding.bounding_boxes import get_bbox_from_mask, bounding_box_to_slice
 
 import nnunetv2
 from nnunetv2.utilities.find_class_by_name import recursive_find_python_class

--- a/spineps/utils/export_prediction.py
+++ b/spineps/utils/export_prediction.py
@@ -1,6 +1,7 @@
 # Adapted from https://github.com/MIC-DKFZ/nnUNet
 # Isensee, F., Jaeger, P. F., Kohl, S. A., Petersen, J., & Maier-Hein, K. H. (2021). nnU-Net: a self-configuring
 # method for deep learning-based biomedical image segmentation. Nature methods, 18(2), 203-211.
+from __future__ import annotations
 
 import os
 from copy import deepcopy

--- a/spineps/utils/find_min_cost_path.py
+++ b/spineps/utils/find_min_cost_path.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from collections import Counter
 from warnings import warn

--- a/spineps/utils/generate_disc_labels.py
+++ b/spineps/utils/generate_disc_labels.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import cc3d
 import numpy as np
 
+from spineps.utils.compat import zip_strict
 from spineps.utils.image import Image
 
 DISCS_MAP = {2:1, 102: 3, 103: 4, 104: 5,
@@ -198,7 +199,7 @@ def closest_point_seg_to_line(discs_seg, centerline, bounding_boxes):
         # Loop on all the pixels of the segmentation
         min_dist = np.inf
         nonzero = np.where(zer>0)
-        for u, v, w in zip(nonzero[0], nonzero[1], nonzero[2]):
+        for u, v, w in zip_strict(nonzero[0], nonzero[1], nonzero[2]):
             _, dist = project_point_on_line(np.array([u, v, w]), centerline)
             if dist < min_dist:
                 min_dist = dist

--- a/spineps/utils/generate_disc_labels.py
+++ b/spineps/utils/generate_disc_labels.py
@@ -3,6 +3,8 @@ This script generates discs labels using SPINEPS' vertebrae segmentation
 
 Author: Nathan Molinier
 '''
+from __future__ import annotations
+
 import argparse
 from pathlib import Path
 
@@ -196,7 +198,7 @@ def closest_point_seg_to_line(discs_seg, centerline, bounding_boxes):
         # Loop on all the pixels of the segmentation
         min_dist = np.inf
         nonzero = np.where(zer>0)
-        for u, v, w in zip(nonzero[0], nonzero[1], nonzero[2], strict=True):
+        for u, v, w in zip(nonzero[0], nonzero[1], nonzero[2]):
             _, dist = project_point_on_line(np.array([u, v, w]), centerline)
             if dist < min_dist:
                 min_dist = dist

--- a/spineps/utils/get_network_from_plans.py
+++ b/spineps/utils/get_network_from_plans.py
@@ -1,6 +1,8 @@
 # Adapted from https://github.com/MIC-DKFZ/nnUNet
 # Isensee, F., Jaeger, P. F., Kohl, S. A., Petersen, J., & Maier-Hein, K. H. (2021). nnU-Net: a self-configuring
 # method for deep learning-based biomedical image segmentation. Nature methods, 18(2), 203-211.
+from __future__ import annotations
+
 from dynamic_network_architectures.architectures.unet import PlainConvUNet, ResidualEncoderUNet
 from dynamic_network_architectures.building_blocks.helper import get_matching_instancenorm, convert_dim_to_conv_op
 from dynamic_network_architectures.initialization.weight_init import init_last_bn_before_add_to_0

--- a/spineps/utils/image.py
+++ b/spineps/utils/image.py
@@ -1,4 +1,6 @@
 # ruff: noqa
+from __future__ import annotations
+
 import os
 import numpy as np
 import nibabel as nib

--- a/spineps/utils/inference_api.py
+++ b/spineps/utils/inference_api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/spineps/utils/predictor.py
+++ b/spineps/utils/predictor.py
@@ -1,6 +1,8 @@
 # Adapted from https://github.com/MIC-DKFZ/nnUNet
 # Isensee, F., Jaeger, P. F., Kohl, S. A., Petersen, J., & Maier-Hein, K. H. (2021). nnU-Net: a self-configuring
 # method for deep learning-based biomedical image segmentation. Nature methods, 18(2), 203-211.
+from __future__ import annotations
+
 import os
 import traceback
 from typing import Tuple, Union

--- a/spineps/utils/proc_functions.py
+++ b/spineps/utils/proc_functions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import cc3d
 import numpy as np
 from ants.utils.convert_nibabel import from_nibabel

--- a/spineps/utils/seg_modelconfig.py
+++ b/spineps/utils/seg_modelconfig.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from pathlib import Path
 

--- a/spineps/utils/sliding_window_prediction.py
+++ b/spineps/utils/sliding_window_prediction.py
@@ -1,6 +1,8 @@
 # Adapted from https://github.com/MIC-DKFZ/nnUNet
 # Isensee, F., Jaeger, P. F., Kohl, S. A., Petersen, J., & Maier-Hein, K. H. (2021). nnU-Net: a self-configuring
 # method for deep learning-based biomedical image segmentation. Nature methods, 18(2), 203-211.
+from __future__ import annotations
+
 from functools import lru_cache
 
 import numpy as np

--- a/unit_tests/test_compat.py
+++ b/unit_tests/test_compat.py
@@ -1,0 +1,46 @@
+# Call "python -m unittest" on this folder
+# coverage run -m unittest
+# coverage report
+# coverage html
+from __future__ import annotations
+
+import unittest
+
+from spineps.utils.compat import zip_strict
+
+
+class TestZipStrict(unittest.TestCase):
+    def test_equal_length_lists(self):
+        a = [1, 2, 3]
+        b = ["a", "b", "c"]
+        expected = [(1, "a"), (2, "b"), (3, "c")]
+        result = list(zip_strict(a, b))
+        self.assertEqual(result, expected)
+
+    def test_unequal_length_lists(self):
+        a = [1, 2, 3]
+        b = ["a", "b"]
+        with self.assertRaises(ValueError) as context:
+            list(zip_strict(a, b))
+        self.assertIn("Length mismatch", str(context.exception))
+
+    def test_empty_iterables(self):
+        a = []
+        b = []
+        result = list(zip_strict(a, b))
+        self.assertEqual(result, [])
+
+    def test_multiple_iterables(self):
+        a = [1, 2, 3]
+        b = [4, 5, 6]
+        c = [7, 8, 9]
+        expected = [(1, 4, 7), (2, 5, 8), (3, 6, 9)]
+        result = list(zip_strict(a, b, c))
+        self.assertEqual(result, expected)
+
+    def test_generator_iterables(self):
+        a = (x for x in range(3))
+        b = (chr(97 + x) for x in range(3))
+        expected = [(0, "a"), (1, "b"), (2, "c")]
+        result = list(zip_strict(a, b))
+        self.assertEqual(result, expected)

--- a/unit_tests/test_enums.py
+++ b/unit_tests/test_enums.py
@@ -2,6 +2,8 @@
 # coverage run -m unittest
 # coverage report
 # coverage html
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/unit_tests/test_filepaths.py
+++ b/unit_tests/test_filepaths.py
@@ -2,6 +2,8 @@
 # coverage run -m unittest
 # coverage report
 # coverage html
+from __future__ import annotations
+
 import os
 import unittest
 from pathlib import Path

--- a/unit_tests/test_path.py
+++ b/unit_tests/test_path.py
@@ -2,6 +2,8 @@
 # coverage run -m unittest
 # coverage report
 # coverage html
+from __future__ import annotations
+
 import unittest
 from unittest.mock import MagicMock
 

--- a/unit_tests/test_postproc.py
+++ b/unit_tests/test_postproc.py
@@ -2,6 +2,8 @@
 # coverage run -m unittest
 # coverage report
 # coverage html
+from __future__ import annotations
+
 import unittest
 
 from TPTBox import No_Logger

--- a/unit_tests/test_proc_functions.py
+++ b/unit_tests/test_proc_functions.py
@@ -13,6 +13,7 @@ from TPTBox.tests.test_utils import get_test_mri
 
 import spineps
 from spineps.get_models import Segmentation_Model, get_actual_model
+from spineps.utils.compat import zip_strict
 from spineps.utils.proc_functions import clean_cc_artifacts, connected_components_3d, n4_bias
 
 logger = No_Logger()
@@ -40,5 +41,5 @@ class Test_proc_functions(unittest.TestCase):
         l3_cleaned = clean_cc_artifacts(l3, logger=logger, labels=[41, 42, 43, 44, 45, 46, 47, 48, 49])
         l3_cleaned = l3.set_array(l3_cleaned)
         l3_cleaned_volumes = l3_cleaned.volumes()
-        for a, b in zip(l3_volumes.values(), l3_cleaned_volumes.values()):
+        for a, b in zip_strict(l3_volumes.values(), l3_cleaned_volumes.values()):
             self.assertEqual(a, b)

--- a/unit_tests/test_proc_functions.py
+++ b/unit_tests/test_proc_functions.py
@@ -2,6 +2,8 @@
 # coverage run -m unittest
 # coverage report
 # coverage html
+from __future__ import annotations
+
 import os
 import unittest
 from pathlib import Path
@@ -38,5 +40,5 @@ class Test_proc_functions(unittest.TestCase):
         l3_cleaned = clean_cc_artifacts(l3, logger=logger, labels=[41, 42, 43, 44, 45, 46, 47, 48, 49])
         l3_cleaned = l3.set_array(l3_cleaned)
         l3_cleaned_volumes = l3_cleaned.volumes()
-        for a, b in zip(l3_volumes.values(), l3_cleaned_volumes.values(), strict=True):
+        for a, b in zip(l3_volumes.values(), l3_cleaned_volumes.values()):
             self.assertEqual(a, b)

--- a/unit_tests/test_semantic.py
+++ b/unit_tests/test_semantic.py
@@ -2,6 +2,8 @@
 # coverage run -m unittest
 # coverage report
 # coverage html
+from __future__ import annotations
+
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock


### PR DESCRIPTION
- Python Version Compatibility: Updated the project to work with Python 3.9
- Type Hint Adjustments: Replaced the use of the | operator for unions with Union and Optional from the typing module
- Removed the use of strict=True from all zip() calls (since it’s only available in Python 3.10+) and introduced a custom zip_strict function in the compatibility module. This function replicates Python 3.10’s zip(..., strict=True) behavior by converting iterables to lists, verifying equal lengths, and then zipping them together